### PR TITLE
Fixed path issues all throughout the site.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 markdown:         redcarpet
 pygments:         true
 
-baseurl:          ""
+baseurl:          "http://jbranchaud.github.io/splitting-atoms"
 
 # Permalinks
 #permalink:        pretty

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,17 +14,17 @@
   </title>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="{{ site.baseurl }}bower_components/font-awesome-css/css/font-awesome.css">
-  <link rel="stylesheet" href="{{ site.baseurl }}public/css/poole.css">
-  <link rel="stylesheet" href="{{ site.baseurl }}public/css/syntax.css">
-  <link rel="stylesheet" href="{{ site.baseurl }}public/css/hyde.css">
-  <link rel="stylesheet" href="{{ site.baseurl }}public/css/main.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/bower_components/font-awesome-css/css/font-awesome.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/public/css/poole.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/public/css/syntax.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/public/css/hyde.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/public/css/main.css">
   <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
 
   <!-- Icons -->
-  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.baseurl }}public/apple-touch-icon-144-precomposed.png">
-                                 <link rel="shortcut icon" href="{{ site.baseurl }}public/favicon.ico">
+  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.baseurl }}/public/apple-touch-icon-144-precomposed.png">
+                                 <link rel="shortcut icon" href="{{ site.baseurl }}/public/favicon.ico">
 
   <!-- RSS -->
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ site.baseurl }}atom.xml">
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ site.baseurl }}/atom.xml">
 </head>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -7,10 +7,10 @@
 
     <ul class="sidebar-nav">
       <li class="sidebar-nav-item{% if page.title == "Home" %} active{% endif %}">
-        <a href="/">Home</a>
+        <a href="{{ site.baseurl }}">Home</a>
       </li>
       <li class="sidebar-nav-item{% if page.title == "Blog" %} active{% endif %}">
-        <a href="/blog/index.html">Blog</a>
+        <a href="{{ site.baseurl }}blog/index.html">Blog</a>
       </li>
 
       {% comment %}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -7,10 +7,10 @@
 
     <ul class="sidebar-nav">
       <li class="sidebar-nav-item{% if page.title == "Home" %} active{% endif %}">
-        <a href="{{ site.baseurl }}">Home</a>
+        <a href="{{ site.baseurl }}/">Home</a>
       </li>
       <li class="sidebar-nav-item{% if page.title == "Blog" %} active{% endif %}">
-        <a href="{{ site.baseurl }}blog/index.html">Blog</a>
+        <a href="{{ site.baseurl }}/blog/">Blog</a>
       </li>
 
       {% comment %}

--- a/blog/index.html
+++ b/blog/index.html
@@ -21,15 +21,15 @@ title: Blog
 
 <div class="pagination">
   {% if paginator.next_page %}
-    <a class="pagination-item older" href="{{ site.baseurl }}page{{paginator.next_page}}">Older</a>
+    <a class="pagination-item older" href="{{ site.baseurl }}/blog/page{{paginator.next_page}}">Older</a>
   {% else %}
     <span class="pagination-item older">Older</span>
   {% endif %}
   {% if paginator.previous_page %}
     {% if paginator.page == 2 %}
-      <a class="pagination-item newer" href="{{ site.baseurl }}">Newer</a>
+      <a class="pagination-item newer" href="{{ site.baseurl }}/blog/">Newer</a>
     {% else %}
-      <a class="pagination-item newer" href="{{ site.baseurl }}page{{paginator.previous_page}}">Newer</a>
+      <a class="pagination-item newer" href="{{ site.baseurl }}/blog/page{{paginator.previous_page}}">Newer</a>
     {% endif %}
   {% else %}
     <span class="pagination-item newer">Newer</span>

--- a/blog/index.html
+++ b/blog/index.html
@@ -21,15 +21,15 @@ title: Blog
 
 <div class="pagination">
   {% if paginator.next_page %}
-    <a class="pagination-item older" href="/page{{paginator.next_page}}">Older</a>
+    <a class="pagination-item older" href="{{ site.baseurl }}page{{paginator.next_page}}">Older</a>
   {% else %}
     <span class="pagination-item older">Older</span>
   {% endif %}
   {% if paginator.previous_page %}
     {% if paginator.page == 2 %}
-      <a class="pagination-item newer" href="/">Newer</a>
+      <a class="pagination-item newer" href="{{ site.baseurl }}">Newer</a>
     {% else %}
-      <a class="pagination-item newer" href="/page{{paginator.previous_page}}">Newer</a>
+      <a class="pagination-item newer" href="{{ site.baseurl }}page{{paginator.previous_page}}">Newer</a>
     {% endif %}
   {% else %}
     <span class="pagination-item newer">Newer</span>


### PR DESCRIPTION
The paths to the blog, blog posts, and their resources were all off. The solution to this was to utilize a `baseurl` variable in the Jekyll configuration. Then when the site is deployed everything is based on the actual URL. As for during local development, use the `--baseurl=` flag. [source](http://stackoverflow.com/questions/14322329/site-root-github-pages-vs-jekyll-server)
