### PR TITLE
Utilizing baseurl for the pages as well.

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -23,7 +23,7 @@
         {% if node.title != null %}
           {% if node.layout == "page" %}
             <li class="sidebar-nav-item{% if page.url == node.url %} active{% endif %}">
-              <a href="{{ node.url }}">{{ node.title }}</a>
+              <a href="{{ site.baseurl }}{{ node.url }}">{{ node.title }}</a>
             </li>
           {% endif %}
         {% endif %}


### PR DESCRIPTION
Forgot to add the `baseurl` in the previous PR, fixing that now. Annoyed though that `{{ node.url }}` prepends the `/`, breaking the pattern of the other links.
