### PR TITLE
Update baseurl to fix HTTPS issues

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 markdown:         redcarpet
 pygments:         true
 
-baseurl:          'http://jbranchaud.github.io/splitting-atoms'
+baseurl:          '/splitting-atoms'
 
 # Permalinks
 #permalink:        pretty


### PR DESCRIPTION
This fixes #82 so that users aren't given a mixed content warning (or the stylesheets just aren't loaded) when viewing over HTTPS.

I followed the recommendations from:
- http://jekyllrb.com/docs/github-pages/
- http://blog.parkermoore.de/2014/04/27/clearing-up-confusion-around-baseurl/

I didn't look at every page of the site, but I spot checked quite a few of them and nothing appeared broken on my fork.
